### PR TITLE
Fix face card draw logic

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -345,7 +345,7 @@ public:
                     int largeSize = CARD_WIDTH - 20;
                     SDL_Rect dest{ x + 15, y + 20, 45, 70};
                     SDL_RenderCopy(mRenderer, faceTexture, nullptr, &dest);
-                } 
+                } else {
                     // Fallback: use suit texture.
                     SDL_Texture* suitTexture = nullptr;
                     switch(card.suit) {
@@ -364,9 +364,10 @@ public:
                     std::string valueText = cardValueToString(card);
                     SDL_Color textColor = {0, 0, 0, 255};
                     if (card.suit == 1 || card.suit == 2)
-                    textColor = {255, 0, 0, 255}; else
-                    textColor = {0, 0, 0, 255};
-                    
+                        textColor = {255, 0, 0, 255};
+                    else
+                        textColor = {0, 0, 0, 255};
+
                     SDL_Surface* textSurface = TTF_RenderText_Blended(mFont, valueText.c_str(), textColor);
                     if (textSurface) {
                         SDL_Texture* textTexture = SDL_CreateTextureFromSurface(mRenderer, textSurface);
@@ -377,6 +378,7 @@ public:
                         }
                         SDL_FreeSurface(textSurface);
                     }
+                }
                 
             }
         } else {


### PR DESCRIPTION
## Summary
- fix fallback rendering when drawing face cards

## Testing
- `g++ -std=c++17 -c main.cpp` *(fails: SDL2 headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_684466ded00c8320afc47fa543d217c8