### PR TITLE
Fix comment for autoComplete

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -641,7 +641,7 @@ bool win;
         return false;
     }
     
-    // Auto–complete function: moves all eligible cards.
+    // Auto–complete function: processes only a single eligible move per call.
     void autoComplete() {
         // For each card in Waste and Tableaus, if it can be moved to foundation, animate the move.
         // For simplicity, only process one move per call.


### PR DESCRIPTION
## Summary
- clarify that `autoComplete()` moves only one card at a time

## Testing
- `g++ main.cpp -o solitaire -lSDL2 -lSDL2_ttf -lSDL2_image -lSDL2_mixer` *(fails: SDL2 headers not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844684b17488320b1ea65aecfc12272