### PR TITLE
Fix README capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 # solitaire-cpp
 C++ Solitaire 
 
-G++ compile command: 
+g++ compile command: 
 
 g++ main.cpp -o solitaire -lSDL2 -lSDL2_ttf -lSDL2_image -lSDL2_mixer
 
-run command: 
+Run command: 
 
 ./solitaire
-
-


### PR DESCRIPTION
## Summary
- fix g++ compile command header
- capitalize run command header

## Testing
- `g++ main.cpp -o solitaire -lSDL2 -lSDL2_ttf -lSDL2_image -lSDL2_mixer` *(fails: SDL2 headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_6844682e28f48320b6b765868e11b109