### PR TITLE
Remove global undo stack

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -79,7 +79,6 @@ struct DragState {
 // Global containers.
 std::vector<Animation> animations;
 DragState dragState;
-std::stack<class Game> undoStack;
 
 // ---------------------------
 // Utility Functions


### PR DESCRIPTION
## Summary
- remove obsolete global `undoStack`
- ensure the engine methods use the member stack for undo actions

## Testing
- `g++ main.cpp -o solitaire -lSDL2 -lSDL2_ttf -lSDL2_image -lSDL2_mixer` *(fails: SDL2/SDL.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68446841c2108320a6e45e6441830131